### PR TITLE
Fix regex and print xorg conf

### DIFF
--- a/xcal
+++ b/xcal
@@ -17,9 +17,8 @@ def xinput(*args):
 
 
 def get_devs():
-    devs = {int(groups[1]): groups[0] for groups in
-            re.findall(r'↳ (\w.+\w)\s+id=(\d+)\D+slave *pointer',
-                       xinput('--list', '--short'))}
+    groups = re.findall(r'.(\w.+(\w|\(\d+\)))\s+id=(\d+)\D+slave *pointer', xinput('--list', '--short'))
+    devs = {int(group[2]): group[0] for group in groups}
     if not devs:
         print('No suitable input devices found')
         exit(1)

--- a/xcal
+++ b/xcal
@@ -247,6 +247,20 @@ def use_cal(dev, new_cal):
     cal_array = [str(x)+',' for x in new_cal.flatten().tolist()[0]]
     xinput('--set-prop', str(dev), prop_name, *cal_array)
 
+def print_xorg_config(dev_name, new_cal):
+    print("Create a file (for example 99-libinput-ts-calib.conf) in /usr/share/X11/xorg.conf.d/ and put in the following")
+    print()
+    xorg_config = (
+    'Section "InputClass"\n'
+    '    Identifier      "calibration"\n'
+    '    MatchProduct    "{}"\n'
+    '    Option          "CalibrationMatrix"  "{}"\n'
+    'EndSection\n'
+    ).format(
+        str(dev_name),
+        " ".join(map(str, new_cal.flatten().tolist()[0]))
+    )
+    print(xorg_config)
 
 def main():
     devs = get_devs()
@@ -278,5 +292,6 @@ def main():
 
     if new_cal is not None and ask('Use calibration?'):
         use_cal(dev, new_cal)
+        print_xorg_config(devs[dev], new_cal)	
 
 main()


### PR DESCRIPTION
Hi, thanks for this script. I used this to succesfully calibrate my edt-ft5x06 based touchscreen. 
In order to get it to work I had to make a change to the regex so it matches ()'s in the device name (my device name was 'generic ft5x06 (79)').
